### PR TITLE
Set pomm result in return of CUD actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ services: postgresql
 
 before_install:
     - psql -c 'CREATE DATABASE pomm_test' -U postgres -h 127.0.0.1 postgres
-    - psql -c 'CREATE TABLE config (name character varying(25) PRIMARY KEY, value character varying(25))' -U postgres -h 127.0.0.1 pomm_test
+    - psql -c 'CREATE TABLE config (name character varying(25) PRIMARY KEY, value character varying(25), status integer default 1)' -U postgres -h 127.0.0.1 pomm_test
 
     - php -S localhost:8080 -t test/web &> /dev/null &
     - ln -fs parameters.yml.dist test/app/config/parameters.yml

--- a/src/WriteListener.php
+++ b/src/WriteListener.php
@@ -11,6 +11,7 @@
 
 namespace PommProject\ApiPlatform;
 
+use ApiPlatform\Core\Exception\ItemNotFoundException;
 use PommProject\Foundation\Pomm;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
@@ -32,21 +33,33 @@ final class WriteListener
         }
 
         $model = $this->getModel($request);
+        if (null === $model) {
+            return;
+        }
+
         $entity = $event->getControllerResult();
 
+        $action_handled = false;
         switch ($request->getMethod()) {
             case Request::METHOD_POST:
                 $model->insertOne($entity);
+                $action_handled = true;
                 break;
 
             case Request::METHOD_PUT:
                 $fields = array_keys($entity->fields());
                 $model->updateOne($entity, $fields);
+                $action_handled = true;
                 break;
 
             case Request::METHOD_DELETE:
                 $model->deleteOne($entity);
+                $action_handled = true;
                 break;
+        }
+
+        if ($action_handled) {
+            $this->setResult($event, $entity);
         }
     }
 
@@ -71,4 +84,22 @@ final class WriteListener
 
         return $session->getModel($modelName);
     }
+
+    /**
+     * setResult
+     *
+     * @param GetResponseForControllerResultEvent                 $event
+     * @param \PommProject\ModelManager\Model\FlexibleEntity|null $entity
+     * @return WriteListener
+     */
+    private function setResult(GetResponseForControllerResultEvent $event, $entity): self
+    {
+        if (null === $entity) {
+            throw new ItemNotFoundException();
+        }
+
+        $event->setControllerResult($entity);
+
+        return $this;
+     }
 }

--- a/test/src/Entity/AutoStructure/Config.php
+++ b/test/src/Entity/AutoStructure/Config.php
@@ -38,6 +38,7 @@ class Config extends RowStructure
             ->setPrimaryKey(['name'])
             ->addField('name', 'varchar')
             ->addField('value', 'varchar')
+            ->addField('status', 'int')
             ;
     }
 }

--- a/test/tests/Features/pomm.feature
+++ b/test/tests/Features/pomm.feature
@@ -35,7 +35,8 @@ Feature: Pomm bridge for api platform
         """
         {
             "name": "<name>",
-            "value": "<value>"
+            "value": "<value>",
+            "status": 1
         }
         """
 
@@ -53,19 +54,23 @@ Feature: Pomm bridge for api platform
         [
             {
                 "name": "test1",
-                "value": "value1"
+                "value": "value1",
+                "status": 1
             },
             {
                 "name": "test2",
-                "value": "value2"
+                "value": "value2",
+                "status": 1
             },
             {
                 "name": "test3",
-                "value": "value3"
+                "value": "value3",
+                "status": 1
             },
             {
                 "name": "test4",
-                "value": "value4"
+                "value": "value4",
+                "status": 1
             }
         ]
         """
@@ -77,19 +82,23 @@ Feature: Pomm bridge for api platform
         [
             {
                 "name": "test4",
-                "value": "value4"
+                "value": "value4",
+                "status": 1
             },
             {
                 "name": "test3",
-                "value": "value3"
+                "value": "value3",
+                "status": 1
             },
             {
                 "name": "test2",
-                "value": "value2"
+                "value": "value2",
+                "status": 1
             },
             {
                 "name": "test1",
-                "value": "value1"
+                "value": "value1",
+                "status": 1
             }
         ]
         """
@@ -100,7 +109,8 @@ Feature: Pomm bridge for api platform
         """
         {
             "name": "test1",
-            "value": "new_value"
+            "value": "new_value",
+            "status": 1
         }
         """
         Then the response status code should be 200
@@ -108,7 +118,8 @@ Feature: Pomm bridge for api platform
         """
         {
             "name": "test1",
-            "value": "new_value"
+            "value": "new_value",
+            "status": 1
         }
         """
 
@@ -118,7 +129,8 @@ Feature: Pomm bridge for api platform
         """
         {
             "name": "test1",
-            "value": "new_value"
+            "value": "new_value",
+            "status": 1
         }
         """
 
@@ -129,7 +141,8 @@ Feature: Pomm bridge for api platform
         [
             {
                 "name": "test1",
-                "value": "new_value"
+                "value": "new_value",
+                "status": 1
             }
         ]
         """


### PR DESCRIPTION
Hello,

This MR update the WriteListener in order to return the result of the pomm write query.

Before, we return the entity before update, but Postresql can update some fields automatically during the write query. For example with triggers and default value in *INSERT*. With this MR, we have directly the new entity in the HTTP response.

Thanks.