### PR TITLE
Send ResourceClassNotSupportedException when resource non handled

### DIFF
--- a/src/CollectionDataProvider.php
+++ b/src/CollectionDataProvider.php
@@ -12,6 +12,7 @@
 namespace PommProject\ApiPlatform;
 
 use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
+use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 use PommProject\Foundation\Pomm;
 use PommProject\Foundation\Where;
 use PommProject\ModelManager\Model\Model;
@@ -48,6 +49,10 @@ class CollectionDataProvider implements CollectionDataProviderInterface
         }
 
         $modelName = "${resourceClass}Model";
+        if (!class_exists($modelName)) {
+            throw new ResourceClassNotSupportedException();
+        }
+
         $session = $this->pomm->getDefaultSession();
         $model = $session->getModel($modelName);
         $paginator = $model->paginateFindWhere(

--- a/src/ItemDataProvider.php
+++ b/src/ItemDataProvider.php
@@ -12,6 +12,7 @@
 namespace PommProject\ApiPlatform;
 
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
+use ApiPlatform\Core\Exception\ResourceClassNotSupportedException;
 use PommProject\Foundation\Pomm;
 
 class ItemDataProvider implements ItemDataProviderInterface
@@ -38,6 +39,10 @@ class ItemDataProvider implements ItemDataProviderInterface
             $modelName = $context['model:name'];
         } else {
             $modelName = "${resourceClass}Model";
+        }
+
+        if (!class_exists($modelName)) {
+                throw new ResourceClassNotSupportedException();
         }
 
         $model = $session->getModel($modelName);


### PR DESCRIPTION
Hello,

We can write multiple CollectionDataProvider and ItemDataProvider for ApiPlatform  in the same project. ApiPlatform  check alls DataProvider in order to find the right one for the specified resource. The exception *ResourceClassNotSupportedException* tells ApiPlatform that the resource is not handled by the DataProvider.

I thought that adding test for this case would be not very relevant. What do you think?

Thanks